### PR TITLE
Add __iter__ to base class to avoid issues with type checking

### DIFF
--- a/parameterspace/base.py
+++ b/parameterspace/base.py
@@ -15,6 +15,10 @@ class SearchSpace(abc.ABC):
         """The number of parameters in the space."""
 
     @abc.abstractmethod
+    def __iter__(self):
+        """Iterate over the parameters of the space."""
+
+    @abc.abstractmethod
     def seed(self, seed: int) -> None:
         """Reinitialize the random number generator with a new seed."""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "parameterspace"
-version = "0.7.11"
+version = "0.7.12"
 description = "Parametrized hierarchical spaces with flexible priors and transformations."
 readme = "README.md"
 repository = "https://github.com/boschresearch/parameterspace"


### PR DESCRIPTION
This solves linting issues for cases where we do `for param in param_space:` and annotate `param_space: SearchSpace`.