### PR TITLE
Add license to package info

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "parameterspace"
-version = "0.7.11"
+version = "0.7.12"
 description = "Parametrized hierarchical spaces with flexible priors and transformations."
 readme = "README.md"
 repository = "https://github.com/boschresearch/parameterspace"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,9 @@ description = "Parametrized hierarchical spaces with flexible priors and transfo
 readme = "README.md"
 repository = "https://github.com/boschresearch/parameterspace"
 authors = ["Bosch Center for AI, Robert Bosch GmbH"]
+license = "Apache-2.0"
 classifiers = [
-    "License :: Other/Proprietary License",
+    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
I think we missed the license info in pyproject.toml. Or did we leave it out on purpose?