### PR TITLE
Add pydocstyle linter

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -30,6 +30,10 @@ jobs:
         run: |
           poetry run pylint --errors-only parameterspace/
           poetry run pylint --errors-only tests/
+      - name: DocStyle Linting
+        continue-on-error: true
+        if: always()
+        run: poetry run pydocstyle
       - name: Run tests
         if: always()
         run: poetry run pytest

--- a/poetry.lock
+++ b/poetry.lock
@@ -1123,6 +1123,25 @@ url = "https://pypi.python.org/simple"
 reference = "public-pypi"
 
 [[package]]
+name = "pydocstyle"
+version = "6.1.1"
+description = "Python docstring style checker"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+snowballstemmer = "*"
+
+[package.extras]
+toml = ["toml"]
+
+[package.source]
+type = "legacy"
+url = "https://pypi.python.org/simple"
+reference = "public-pypi"
+
+[[package]]
 name = "pygments"
 version = "2.9.0"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -1400,6 +1419,19 @@ url = "https://pypi.python.org/simple"
 reference = "public-pypi"
 
 [[package]]
+name = "snowballstemmer"
+version = "2.1.0"
+description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.source]
+type = "legacy"
+url = "https://pypi.python.org/simple"
+reference = "public-pypi"
+
+[[package]]
 name = "testpath"
 version = "0.5.0"
 description = "Test utilities for code working with files and commands"
@@ -1607,7 +1639,7 @@ examples = []
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4.0"
-content-hash = "603c2ce8c37eeefee04c1b8cdc3934049960bd476df7a6e8a1e7a9206b0b345a"
+content-hash = "eead3ef28421a3bf1902fee05a0fb59b412f0cbb758a6ec7c9e0bf5bea5d9fb1"
 
 [metadata.files]
 appdirs = [
@@ -2062,6 +2094,10 @@ pycparser = [
     {file = "pycparser-2.20-py2.py3-none-any.whl", hash = "sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705"},
     {file = "pycparser-2.20.tar.gz", hash = "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0"},
 ]
+pydocstyle = [
+    {file = "pydocstyle-6.1.1-py3-none-any.whl", hash = "sha256:6987826d6775056839940041beef5c08cc7e3d71d63149b48e36727f70144dc4"},
+    {file = "pydocstyle-6.1.1.tar.gz", hash = "sha256:1d41b7c459ba0ee6c345f2eb9ae827cab14a7533a88c5c6f7e94923f72df92dc"},
+]
 pygments = [
     {file = "Pygments-2.9.0-py3-none-any.whl", hash = "sha256:d66e804411278594d764fc69ec36ec13d9ae9147193a1740cd34d272ca383b8e"},
     {file = "Pygments-2.9.0.tar.gz", hash = "sha256:a18f47b506a429f6f4b9df81bb02beab9ca21d0a5fee38ed15aef65f0545519f"},
@@ -2269,6 +2305,10 @@ scipy = [
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+snowballstemmer = [
+    {file = "snowballstemmer-2.1.0-py2.py3-none-any.whl", hash = "sha256:b51b447bea85f9968c13b650126a888aabd4cb4463fca868ec596826325dedc2"},
+    {file = "snowballstemmer-2.1.0.tar.gz", hash = "sha256:e997baa4f2e9139951b6f4c631bad912dfd3c792467e2f03d7239464af90e914"},
 ]
 testpath = [
     {file = "testpath-0.5.0-py3-none-any.whl", hash = "sha256:8044f9a0bab6567fc644a3593164e872543bb44225b0e24846e2c89237937589"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ pytest-rerunfailures = "^10.1"
 num2tex = "^0.8"
 mkdocs-jupyter = "^0.17.3"
 mike = "^1.0.1"
+pydocstyle = "^6.1.1"
 
 [tool.poetry.extras]
 examples = ["notebook", "matplotlib"]
@@ -86,6 +87,12 @@ disable = [
     "too-many-arguments",
     "too-few-public-methods"
 ]
+
+[tool.pydocstyle]
+convention = "google"
+add-ignore = "D105"
+match = '(?!test_|__init__).*\.py'
+match-dir = '[^\tests].*'
 
 [tool.coverage.run]
 source = ['parameterspace']


### PR DESCRIPTION
Adds [pydocstyle](https://github.com/PyCQA/pydocstyle) for linting google-styled docs. Check is added to gh action, but with the "continue-on-error" switch, as we have to fix quite a bunch of issues first (and/or adjust the linter config).

Hints:
- Contributors using `vscode` can easily enable issue-highlighting by enabling `python.linting.pydocstyleEnabled` in the settings UI.
- In CLI just run `pydocstyle` (or `pydocstyle --explain` for more details)
- 
Signed-off-by: Buech Holger <holger.buech@de.bosch.com>