### PR TITLE
fix integer param log transform numerical conversion

### DIFF
--- a/parameterspace/transformations/log_zero_one.py
+++ b/parameterspace/transformations/log_zero_one.py
@@ -78,11 +78,11 @@ class LogZeroOneInteger(BaseTransformation):
         """
         [summary]
         """
-        return int(
-            np.around(
+        integer_value = np.around(
                 np.exp(self.log_bounds[0] + numerical_value * (self.log_interval_size))
-            )
         )
+        # clip result to bound due to rounding problems when the numerical value is 0.0
+        return int(np.clip(integer_value, *self.input_bounds))
 
     def __call__(self, value: Any) -> float:
         return float((np.log(value) - self.log_bounds[0]) / self.log_interval_size)

--- a/parameterspace/transformations/log_zero_one.py
+++ b/parameterspace/transformations/log_zero_one.py
@@ -79,7 +79,7 @@ class LogZeroOneInteger(BaseTransformation):
         [summary]
         """
         integer_value = np.around(
-                np.exp(self.log_bounds[0] + numerical_value * (self.log_interval_size))
+            np.exp(self.log_bounds[0] + numerical_value * (self.log_interval_size))
         )
         # clip result to bound due to rounding problems when the numerical value is 0.0
         return int(np.clip(integer_value, *self.input_bounds))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "parameterspace"
-version = "0.7.13"
+version = "0.7.14"
 description = "Parametrized hierarchical spaces with flexible priors and transformations."
 readme = "README.md"
 repository = "https://github.com/boschresearch/parameterspace"

--- a/tests/test_parameterspace.py
+++ b/tests/test_parameterspace.py
@@ -728,13 +728,14 @@ def test_continuous_parameter_with_log_transform_on_boundaries():
 
     config = space.from_numerical(np.array([0.0]))
     vector = space.to_numerical(config)
-    assert config["p1"] == 1.
+    assert config["p1"] == 1.0
     assert (vector == 0).all()
 
     config = space.from_numerical(np.array([1.0]))
     vector = space.to_numerical(config)
-    assert config["p1"] == 32.
+    assert config["p1"] == 32.0
     assert (vector == 1).all()
+
 
 if __name__ == "__main__":
     pytest.main(["--pdb", "-s", __file__])

--- a/tests/test_parameterspace.py
+++ b/tests/test_parameterspace.py
@@ -703,23 +703,38 @@ def test_fix_with_inactive_constants():
     assert not space.has_conditions()
 
 
-def test_integer_parameter_with_log_transform_from_and_to_numerical_zero_is_finite():
+def test_integer_parameter_with_log_transform_on_boundaries():
+    """Make sure that the log transformation works on the boundaries of the interval."""
     space = ps.ParameterSpace()
     space.add(ps.IntegerParameter("p1", bounds=(1, 32), transformation="log"))
+
     config = space.from_numerical(np.array([0.0]))
     vector = space.to_numerical(config)
-    assert np.isfinite(vector).all(), vector
-    assert vector[0] == 0.0
+    assert config["p1"] == 1
+    assert (vector >= 0).all()
+    assert (vector <= 1).all()
+
+    config = space.from_numerical(np.array([1.0]))
+    vector = space.to_numerical(config)
+    assert config["p1"] == 32
+    assert (vector >= 0).all()
+    assert (vector <= 1).all()
 
 
-def test_continuous_parameter_with_log_transform_from_and_to_numerical_zero_is_finite():
+def test_continuous_parameter_with_log_transform_on_boundaries():
+    """Make sure that the log transformation works on the boundaries of the interval."""
     space = ps.ParameterSpace()
     space.add(ps.ContinuousParameter("p1", bounds=(1.0, 32.0), transformation="log"))
+
     config = space.from_numerical(np.array([0.0]))
     vector = space.to_numerical(config)
-    assert np.isfinite(vector).all(), vector
-    assert vector[0] == 0.0
+    assert config["p1"] == 1.
+    assert (vector == 0).all()
 
+    config = space.from_numerical(np.array([1.0]))
+    vector = space.to_numerical(config)
+    assert config["p1"] == 32.
+    assert (vector == 1).all()
 
 if __name__ == "__main__":
     pytest.main(["--pdb", "-s", __file__])

--- a/tests/test_parameterspace.py
+++ b/tests/test_parameterspace.py
@@ -703,5 +703,23 @@ def test_fix_with_inactive_constants():
     assert not space.has_conditions()
 
 
+def test_integer_parameter_with_log_transform_from_and_to_numerical_zero_is_finite():
+    space = ps.ParameterSpace()
+    space.add(ps.IntegerParameter("p1", bounds=(1, 32), transformation="log"))
+    config = space.from_numerical(np.array([0.0]))
+    vector = space.to_numerical(config)
+    assert np.isfinite(vector).all(), vector
+    assert vector[0] == 0.0
+
+
+def test_continuous_parameter_with_log_transform_from_and_to_numerical_zero_is_finite():
+    space = ps.ParameterSpace()
+    space.add(ps.ContinuousParameter("p1", bounds=(1.0, 32.0), transformation="log"))
+    config = space.from_numerical(np.array([0.0]))
+    vector = space.to_numerical(config)
+    assert np.isfinite(vector).all(), vector
+    assert vector[0] == 0.0
+
+
 if __name__ == "__main__":
     pytest.main(["--pdb", "-s", __file__])


### PR DESCRIPTION
I noticed that converting from numerical zero and back fails for integer log transforms as it seems because of our rounding implementation. I'd be curious to get your take on the issue @sfalkner.