### PR TITLE
Add option to get a parameter by its name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 A package to define parameter spaces consisting of mixed types (continuous, integer,
 categorical) with conditions and priors. It allows for easy specification of the
 parameters and their dependencies. The `ParameterSpace` object can then be used to
-sample random random configurations from the prior and convert any valid configuration
+sample random configurations from the prior and convert any valid configuration
 into a numerical representation. This numerical representation has the following
 properties:
 

--- a/parameterspace/parameterspace.py
+++ b/parameterspace/parameterspace.py
@@ -255,6 +255,25 @@ class ParameterSpace(SearchSpace):
         """
         return list(self._parameters.keys())
 
+    def get_parameter_by_name(self, name: str) -> BaseParameter:
+        """Get parameter with the given name.
+
+        Args:
+            name: Name of the parameter.
+
+        Returns:
+            Parameter with the given name.
+
+        Raises:
+            KeyError: In case parameter doesn't exist.
+        """
+        try:
+            return self._parameters[name]
+        except KeyError as e:
+            raise KeyError(
+                f"Parameter '{name}' is not part of the ParameterSpace."
+            ) from e
+
     def sample(
         self, partial_configuration: dict = None, rng: np.random.Generator = None
     ) -> dict:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "parameterspace"
-version = "0.7.14"
+version = "0.7.15"
 description = "Parametrized hierarchical spaces with flexible priors and transformations."
 readme = "README.md"
 repository = "https://github.com/boschresearch/parameterspace"

--- a/tests/test_parameterspace.py
+++ b/tests/test_parameterspace.py
@@ -46,6 +46,10 @@ def test_simple_space():
     assert names[1] == "p2"
     assert not space.has_conditions()
 
+    assert space.get_parameter_by_name("p1")["parameter"] == p1
+    with pytest.raises(KeyError):
+        space.get_parameter_by_name("p3")
+
     sample1 = space.sample(rng=np.random.default_rng(42))
     sample2 = space.sample(rng=np.random.default_rng(42))
 


### PR DESCRIPTION
In emukit (https://github.com/EmuKit/emukit/blob/main/emukit/core/parameter_space.py#L77), there is a function get_parameter_by_name(), which allowed a convenient usage in NumpyBO, e.g., when getting (non)-contextual parameters. The equivalent function is missing in the parameterspace package here, which is addressed now in this PR.

Signed-off-by: Attila Reiss