### PR TITLE
"in" conditions deserialization

### DIFF
--- a/parameterspace/utils.py
+++ b/parameterspace/utils.py
@@ -98,7 +98,7 @@ def verify_lambda(variables: List[str], body: str) -> bool:
         if c in body:
             return False
 
-    allowed_characters = ".0123456789+-*/()<=!> "
+    allowed_characters = ".,0123456789+-*/()<=!> "
     allowed_functions = [
         "math.sin",
         "math.cos",
@@ -107,6 +107,7 @@ def verify_lambda(variables: List[str], body: str) -> bool:
         "or",
         "and",
         "not",
+        "in",
     ]
 
     for vn in variables:

--- a/parameterspace/utils.py
+++ b/parameterspace/utils.py
@@ -6,7 +6,7 @@
 import os
 import re
 from functools import wraps
-from typing import Callable, Iterable, Tuple
+from typing import Callable, Iterable, List, Tuple
 
 import numpy as np
 
@@ -75,15 +75,15 @@ def extract_lambda_information(source_lines: Iterable) -> Tuple[list, str]:
     return variables, body.strip().rstrip(",")
 
 
-def verify_lambda(variables: list, body: str) -> bool:
+def verify_lambda(variables: List[str], body: str) -> bool:
     """Check serialized lambda expression for malicious code.
 
     Args:
-        variables: [description]
-        body: [description]
+        variables: List of the variable names used in the function body.
+        body: Function body string representation to check for allowed expressions.
 
     Returns:
-        [description]
+        True if the function body is considered safe.
     """
 
     if len(body) > 200:
@@ -92,14 +92,14 @@ def verify_lambda(variables: list, body: str) -> bool:
     if "eval(" in body:
         return False
 
-    blacklisted_characters = "\\;"
+    forbidden_characters = "\\;"
 
-    for c in blacklisted_characters:
+    for c in forbidden_characters:
         if c in body:
             return False
 
-    white_listed_chars = ".0123456789+-*/()<=!> "
-    white_listed_functions = [
+    allowed_characters = ".0123456789+-*/()<=!> "
+    allowed_functions = [
         "math.sin",
         "math.cos",
         "math.exp",
@@ -112,10 +112,10 @@ def verify_lambda(variables: list, body: str) -> bool:
     for vn in variables:
         body = body.replace(vn, "")
 
-    for fn in white_listed_functions:
+    for fn in allowed_functions:
         body = body.replace(fn, "")
 
-    for c in white_listed_chars:
+    for c in allowed_characters:
         body = body.replace(c, "")
 
     # remove all single quoted strings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "parameterspace"
-version = "0.7.20"
+version = "0.7.21"
 description = "Parametrized hierarchical spaces with flexible priors and transformations."
 readme = "README.md"
 repository = "https://github.com/boschresearch/parameterspace"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -51,6 +51,8 @@ def test_extract_lambda_information():
         ("math", (lambda p1, p2: math.sin(p1 + p2)), True),
         # string expressions should be ok
         ("string", (lambda p1: p1 == "foo"), True),
+        # tuple member check should be ok
+        ("tuple member", (lambda p1: p1 in ("a", "b")), True),
         # logic operators should work too
         ("logic", (lambda p1, p2: p1 == 1 or not p2 == 1 and p1 != p2), True),
         # Uneven single quotes should work

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -44,63 +44,51 @@ def test_extract_lambda_information():
         assert body == expected_body
 
 
-def test_verify_lambda():
+@pytest.mark.parametrize(
+    "label,function,expected_to_pass",
+    [
+        ("squared", (lambda p1, p2: p1**2 + p2**2 < 1), True),
+        ("math", (lambda p1, p2: math.sin(p1 + p2)), True),
+        # string expressions should be ok
+        ("string", (lambda p1: p1 == "foo"), True),
+        # logic operators should work too
+        ("logic", (lambda p1, p2: p1 == 1 or not p2 == 1 and p1 != p2), True),
+        # Uneven single quotes should work
+        ("uneven single", (lambda p1: p1 == "a single ' is okay"), True),
+        # Uneven double quotes should work
+        ("uneven double", (lambda p1: p1 == 'a single " is okay'), True),
+        # eval is a red flag
+        # pylint: disable=eval-used
+        ("eval", (lambda: eval("print('I could be malicious!')")), False),
+        # body can't be too long
+        # pylint: disable=line-too-long
+        (
+            "long body",
+            lambda: (
+                "Very long string to trigger the upper character limit. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores"
+            ),
+            False,
+        ),
+        # backslash is a forbidden character
+        ("backslash", (lambda: print("\\")), False),
+        # numpy is currently not allowed
+        # pylint: disable=unnecessary-lambda
+        ("numpy", (lambda p1: np.cos(p1)), False),
+    ],
+)
+def test_verify_lambda(label, function, expected_to_pass):
     """Test verification of some example lambda functions
 
     See comment in `test_extract_lambda_information` above.
+    The `label` argument is mainly intended to improve readability of sub-test names.
     """
 
-    functions = []
-    expected_to_pass = []
-
-    functions.append(lambda p1, p2: p1**2 + p2**2 < 1)
-    expected_to_pass.append(True)
-
-    functions.append(lambda p1, p2: math.sin(p1 + p2))
-    expected_to_pass.append(True)
-
-    # string expressions should be ok
-    functions.append(lambda p1, p2: p1 == "foo")
-    expected_to_pass.append(True)
-
-    # logic operators should work too
-    functions.append(lambda p1, p2: p1 == 1 or not p2 == 1 and p1 != p2)
-    expected_to_pass.append(True)
-
-    # Uneven single quotes should work
-    functions.append(lambda p1: p1 == "a single ' is okay")
-    expected_to_pass.append(True)
-
-    # Uneven double quotes should work
-    functions.append(lambda p1: p1 == 'a single " is okay')
-    expected_to_pass.append(True)
-
-    # eval is a red flag
-    # pylint: disable=eval-used
-    functions.append(lambda: eval("print('I could be malicious!')"))
-    expected_to_pass.append(False)
-
-    # body can't be too long
-    # pylint: disable=line-too-long
-    functions.append(
-        lambda: "Very long string to trigger the upper character limit. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores"
+    variables, body = utils.extract_lambda_information(
+        inspect.getsourcelines(function)[0]
     )
-    expected_to_pass.append(False)
-
-    # backslash is a blacklisted character
-    functions.append(lambda: print("\\"))
-    expected_to_pass.append(False)
-
-    # numpy is currently not white listed
-    # pylint: disable=unnecessary-lambda
-    functions.append(lambda p1: np.cos(p1))
-    expected_to_pass.append(False)
-
-    for lambda_fn, pass_expected in zip(functions, expected_to_pass):
-        variables, body = utils.extract_lambda_information(
-            inspect.getsourcelines(lambda_fn)[0]
-        )
-        assert pass_expected == utils.verify_lambda(variables, body)
+    assert expected_to_pass == utils.verify_lambda(
+        variables, body
+    ), f"{label} expected {expected_to_pass}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds support for `lambda p1: p1 in ("a", "b")` style conditions to be considered safe for de-serialization. This removes the burden to construct `lambda p1: p1 == "a" or p1 == "b"` style conditions. The attack surface increases a bit because we do not only need to allow `in` but also `,`.