### PR TITLE
validate parameter names for compatibility with fix and conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,21 @@ For serving it locally while working on the documentation run:
 poetry run mkdocs serve
 ```
 
+## Architectural Decision Records
+
+### Parameter Names
+
+**In the context of** naming parameters and using their name to fix them to constant
+values or condition on them via `lambda` expressions,
+**facing that** only valid Python variable names can be used in conditions, and that
+fixing parameters that do not have a valid parameter name can only be done like
+`fix(**{"invalid-variable:name": "const"})`
+**we decided for** requiring all parameter names to be valid Python variable names
+**to achieve** early failure and communication of that convention to avoid surprises
+when fixing and using conditions down the line, accepting that this rules out common
+parameter names like `lambda` and might require explicit translation between from and to
+contexts that require incompatible names (e.g. predefined benchmarks).
+
 ## License
 
 `parameterspace` is open-sourced under the Apache-2.0 license. See the

--- a/parameterspace/parameters/base.py
+++ b/parameterspace/parameters/base.py
@@ -6,12 +6,17 @@
 import abc
 import copy
 import importlib
+from keyword import iskeyword
 from typing import Dict, Optional, Tuple, Union
 
 import numpy as np
 
 from parameterspace.priors.base import BasePrior
 from parameterspace.transformations.base import BaseTransformation
+
+
+def _is_valid_python_variable_name(name: str) -> bool:
+    return name.isidentifier() and not iskeyword(name)
 
 
 class BaseParameter(abc.ABC):
@@ -33,22 +38,25 @@ class BaseParameter(abc.ABC):
         Args:
             name: Name of the parameter.
             prior: Defines the pdf from which random samples are drawn. Default (`None`)
-                correponds to a uniform prior. Note that the prior's bounds must match
+                corresponds to a uniform prior. Note that the prior's bounds must match
                 the transformation's output bounds.
-            transformation: Defines the tranformation from the values to their numerical
-                representaiton. Note that the transformation's output bounds must match
-                the prior's bounds.
+            transformation: Defines the transformation from the values to their
+                numerical representation. Note that the transformation's output bounds
+                must match the prior's bounds.
             is_continuous: Indicates whether this parameter varies continuously, i.e.
                 is a `float`.
             is_ordered: Indicates whether this parameter has a natural ordering of it's
                 values.
             num_values: Number of possible values. For ordinal, categorical, and integer
                 parameters, this equals the number of unique values. For continuous
-                parameters, it equals np.inf (eventhough technically there is only a
+                parameters, it equals np.inf (even though technically there is only a
                 finite number of float values).
             inactive_numerical_value: Placeholder value for this parameter in case it
                 is not active
         """
+        if not _is_valid_python_variable_name(name):
+            raise ValueError(f"{name} needs to be a valid Python variable name.")
+
         self.name = name
         self._prior = prior
         self._transformation = transformation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "parameterspace"
-version = "0.7.22"
+version = "0.8.0"
 description = "Parametrized hierarchical spaces with flexible priors and transformations."
 readme = "README.md"
 repository = "https://github.com/boschresearch/parameterspace"

--- a/tests/parameters/test_base.py
+++ b/tests/parameters/test_base.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np
+import pytest
 
 from parameterspace.parameters.base import BaseParameter
 from parameterspace.priors.uniform import Uniform
@@ -59,3 +60,18 @@ def test_base_parameter():
         )
 
     assert p != q
+
+
+@pytest.mark.parametrize(
+    "name", ["param-name", "param:name", "param name", "123", "lambda", "def"]
+)
+def test_raises_on_invalid_name(name):
+    with pytest.raises(ValueError, match=name):
+        PseudoParameter(
+            name,
+            prior=Uniform(),
+            transformation=ZeroOneFloat(np.array((0, 1))),
+            is_continuous=False,
+            is_ordered=False,
+            num_values=np.inf,
+        )

--- a/tests/test_configspace_utils.py
+++ b/tests/test_configspace_utils.py
@@ -46,7 +46,7 @@ CS_CONDITIONS_JSON = """{
       "probabilities": null
     },
     {
-      "name": "lambda",
+      "name": "lmbd",
       "type": "uniform_float",
       "log": true,
       "lower": 0.0009118819655545162,
@@ -122,7 +122,7 @@ def test_conditions_and_log_transform():
         {
             "alpha": 1.0,
             "booster": "gbtree",
-            "lambda": 1.0,
+            "lmbd": 1.0,
             "nrounds": 122,
             "repl": 6,
             "max_depth": 3,

--- a/tests/test_configspace_utils.py
+++ b/tests/test_configspace_utils.py
@@ -46,7 +46,7 @@ CS_CONDITIONS_JSON = """{
       "probabilities": null
     },
     {
-      "name": "lmbd",
+      "name": "lambda_",
       "type": "uniform_float",
       "log": true,
       "lower": 0.0009118819655545162,
@@ -122,7 +122,7 @@ def test_conditions_and_log_transform():
         {
             "alpha": 1.0,
             "booster": "gbtree",
-            "lmbd": 1.0,
+            "lambda_": 1.0,
             "nrounds": 122,
             "repl": 6,
             "max_depth": 3,


### PR DESCRIPTION
Given that one can only fix parameters to a constant (with `space.fix(param1="constant value")`) or use them in conditions if they are valid Python variable names, let's fail as early as possible if someone tries to use a parameter name that isn't, so that people don't get frustrated later but instead learn about that convention early.
Also, some typo fixes in a docstring.