### PR TITLE
fix to latex tbl fails with ordinal only (closes #58)

### DIFF
--- a/parameterspace/parameterspace.py
+++ b/parameterspace/parameterspace.py
@@ -19,6 +19,7 @@ from parameterspace.parameters import (
     CategoricalParameter,
     ContinuousParameter,
     IntegerParameter,
+    OrdinalParameter,
 )
 from parameterspace.parameters.base import BaseParameter
 
@@ -525,7 +526,7 @@ class ParameterSpace(SearchSpace):
                 transformation_str = "Log" if "Log" in transformation_name else ""
                 prior_str = prior_name
 
-            if isinstance(parameter, ContinuousParameter):
+            elif isinstance(parameter, ContinuousParameter):
                 type_str = "Float"
                 prior_str = prior_name
 
@@ -538,7 +539,7 @@ class ParameterSpace(SearchSpace):
                     transformation_str = " "
                     values_str = f"$[{parameter.bounds[0]}, {parameter.bounds[1]}]$"
 
-            if isinstance(parameter, CategoricalParameter):
+            elif isinstance(parameter, CategoricalParameter):
                 type_str = "Categorical"
                 values_str = "[" + ", ".join(parameter.values) + "]"
                 transformation_str = " "
@@ -546,6 +547,15 @@ class ParameterSpace(SearchSpace):
                 prior_str = (
                     "[" + ",".join(map(lambda p: f"{p:3.2f}", prior_probs)) + "]"
                 )
+
+            elif isinstance(parameter, OrdinalParameter):
+                type_str = "Ordinal"
+                values_str = "[" + ", ".join(parameter.values) + "]"
+                transformation_str = " "
+                prior_str = prior_name
+
+            else:
+                raise ValueError(f"Unknown parameter type {type(parameter)}")
 
             latex_strs.append(
                 " & ".join(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "parameterspace"
-version = "0.9.0"
+version = "0.9.1"
 description = "Parametrized hierarchical spaces with flexible priors and transformations."
 readme = "README.md"
 repository = "https://github.com/boschresearch/parameterspace"


### PR DESCRIPTION
In `to_latex_table` we were missing support for `OrdinalParameter` but the corresponding test didn't catch it because the ordinal parameter wasn't the first one and hence in the loop, all variables for the corresponding `latex_strs.append` operation were populated from the previous iteration. This PR both introduces else if conditions with an explicit else case for unknown parameter types, as well as adds support for a latex table representation of ordinal parameters.