### PR TITLE
return name mapping for invalid names when loading configspace

### DIFF
--- a/parameterspace/configspace_utils.py
+++ b/parameterspace/configspace_utils.py
@@ -6,53 +6,25 @@ import numpy as np
 
 import parameterspace as ps
 from parameterspace.condition import Condition
-from parameterspace.utils import verify_lambda
-
-RESERVED_WORDS = [
-    "and",
-    "as",
-    "assert",
-    "break",
-    "class",
-    "continue",
-    "def",
-    "del",
-    "elif",
-    "else",
-    "except",
-    "finally",
-    "for",
-    "form",
-    "global",
-    "if",
-    "import",
-    "in",
-    "is",
-    "lambda",
-    "nonlocal",
-    "not",
-    "or",
-    "pass",
-    "raise",
-    "return",
-    "try",
-    "while",
-    "with",
-    "yield",
-]
+from parameterspace.utils import is_valid_python_variable_name, verify_lambda
 
 
 def _escape_parameter_name(name: str) -> str:
     """Replace colons, dashes, dots and spaces with an underscore and add an underscore
     suffix to reserved Python words.
     """
-    name = name.replace(":", "_").replace("-", "_").replace(".", "_").replace(" ", "_")
+    _name = name.replace(":", "_").replace("-", "_").replace(".", "_").replace(" ", "_")
 
-    for reserved_word in RESERVED_WORDS:
-        if name == reserved_word:
-            name = f"{name}_"
+    if not is_valid_python_variable_name(_name):
+        _name = f"{_name}_"
 
-    return name
+    if not is_valid_python_variable_name(_name):
+        raise ValueError(
+            f'Failed to transform "{name}" into a valid parameter name, '
+            + f'ended up with "{_name}".'
+        )
+
+    return _name
 
 
 def _get_condition(

--- a/parameterspace/parameters/base.py
+++ b/parameterspace/parameters/base.py
@@ -6,17 +6,13 @@
 import abc
 import copy
 import importlib
-from keyword import iskeyword
 from typing import Dict, Optional, Tuple, Union
 
 import numpy as np
 
 from parameterspace.priors.base import BasePrior
 from parameterspace.transformations.base import BaseTransformation
-
-
-def _is_valid_python_variable_name(name: str) -> bool:
-    return name.isidentifier() and not iskeyword(name)
+from parameterspace.utils import is_valid_python_variable_name
 
 
 class BaseParameter(abc.ABC):
@@ -54,7 +50,7 @@ class BaseParameter(abc.ABC):
             inactive_numerical_value: Placeholder value for this parameter in case it
                 is not active
         """
-        if not _is_valid_python_variable_name(name):
+        if not is_valid_python_variable_name(name):
             raise ValueError(f"{name} needs to be a valid Python variable name.")
 
         self.name = name

--- a/parameterspace/utils.py
+++ b/parameterspace/utils.py
@@ -6,6 +6,7 @@
 import os
 import re
 from functools import wraps
+from keyword import iskeyword
 from typing import Callable, Iterable, List, Tuple
 
 import numpy as np
@@ -134,3 +135,7 @@ def verify_lambda(variables: List[str], body: str) -> bool:
         return False
 
     return True
+
+
+def is_valid_python_variable_name(name: str) -> bool:
+    return name.isidentifier() and not iskeyword(name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "parameterspace"
-version = "0.9.1"
+version = "0.10.0"
 description = "Parametrized hierarchical spaces with flexible priors and transformations."
 readme = "README.md"
 repository = "https://github.com/boschresearch/parameterspace"


### PR DESCRIPTION
Since we have restricted the valid parameter names in parameterspace release 0.8.0 to a subset of the names allowed with ConfigSpace, this PR returns a mapping between the config space and parameterspace conforming names to translate back and forth between the two domains.