### PR TITLE
Feature: add parameters via method chaining

### DIFF
--- a/parameterspace/parameterspace.py
+++ b/parameterspace/parameterspace.py
@@ -81,7 +81,7 @@ class ParameterSpace(SearchSpace):
         self,
         parameter: Union[BaseParameter, ParameterSpace],
         condition: Optional[Callable] = None,
-    ):
+    ) -> "ParameterSpace":
         """Add a parameter that is only active if condition returns true when called.
 
         Args:
@@ -113,6 +113,7 @@ class ParameterSpace(SearchSpace):
                 "parameter": parameter,
                 "condition": condition,
             }
+        return self
 
     def to_dict(self) -> dict:
         """

--- a/tests/test_parameterspace.py
+++ b/tests/test_parameterspace.py
@@ -56,6 +56,23 @@ def test_simple_space():
     assert sample1 == sample2
 
 
+def test_add_parameters_by_method_chaining():
+    space = (
+        ParameterSpace()
+        .add(IntegerParameter("p1", (-5, 5)))
+        .add(ContinuousParameter("p2", (0, 5)))
+        .add(CategoricalParameter("p3", ["foo", "bar"]))
+        .add(OrdinalParameter("p4", ["cold", "warm", "hot"]))
+    )
+
+    names = space.get_parameter_names()
+
+    assert "p1" in names
+    assert "p2" in names
+    assert "p3" in names
+    assert "p4" in names
+
+
 def test_seeded_parameterspace():
     p1 = IntegerParameter("p1", (-5, 5))
     p2 = ContinuousParameter(


### PR DESCRIPTION
The current way to construct a `ParameterSpace` is
```python
space = ParameterSpace()
space = space.add(...)
space = space.add(...)
space = space.add(...)
...
```

This feels a bit verbose, and method chaining seems a bit more convenient:
```python
space = (
    ParameterSpace()
    .add(...)
    .add(...)
    .add(...)
    ...
)
```

This PR gives the user to choose between both syntaxes.